### PR TITLE
Set Revision on AllowCategoryAsync()

### DIFF
--- a/BytexDigital.Blazor.Components.CookieConsent/CookieConsentService.cs
+++ b/BytexDigital.Blazor.Components.CookieConsent/CookieConsentService.cs
@@ -103,6 +103,7 @@ namespace BytexDigital.Blazor.Components.CookieConsent
             newCategories.Add(category.Identifier);
             newServices.AddRange(category.Services.Select(x => x.Identifier));
 
+            preferences.AcceptedRevision = _options.Value.Revision;
             preferences.AllowedCategories = newCategories.Distinct().ToArray();
             preferences.AllowedServices = newServices.Distinct().ToArray();
 


### PR DESCRIPTION
Bugfix: When the user comes on your page the first time and does not use the modal window to accept the cookies, but the default <NotAllowed> or the AllowCategoryAsync() methode the cookie is created with revision "-1"

Added the revision to AllowCategoryAsync() to fix that.

btw. I love this repo ;-) good work!