### PR TITLE
Add ability to disable auto JS import and add ICookieConsentInterop

### DIFF
--- a/BytexDigital.Blazor.Components.CookieConsent.AspNetCore/BytexDigital.Blazor.Components.CookieConsent.AspNetCore.csproj
+++ b/BytexDigital.Blazor.Components.CookieConsent.AspNetCore/BytexDigital.Blazor.Components.CookieConsent.AspNetCore.csproj
@@ -21,6 +21,11 @@
         <PackageVersion Condition=" '$(VersionSuffix)' != '' ">$(PackageVersion)-$(VersionSuffix)</PackageVersion>
         <PackageReleaseNotes>See https://github.com/BytexDigital/BytexDigital.Blazor.Components.CookieConsent</PackageReleaseNotes>
     </PropertyGroup>
+	
+    <PropertyGroup>
+		<IsTrimmable>true</IsTrimmable>
+		<EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+	</PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />

--- a/BytexDigital.Blazor.Components.CookieConsent.AspNetCore/BytexDigital.Blazor.Components.CookieConsent.AspNetCore.csproj
+++ b/BytexDigital.Blazor.Components.CookieConsent.AspNetCore/BytexDigital.Blazor.Components.CookieConsent.AspNetCore.csproj
@@ -22,10 +22,10 @@
         <PackageReleaseNotes>See https://github.com/BytexDigital/BytexDigital.Blazor.Components.CookieConsent</PackageReleaseNotes>
     </PropertyGroup>
 	
-	<PropertyGroup>
-		<IsTrimmable>true</IsTrimmable>
-		<EnableTrimAnalyzer>true</EnableTrimAnalyzer>
-	</PropertyGroup>
+    <PropertyGroup>
+        <IsTrimmable>true</IsTrimmable>
+        <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />

--- a/BytexDigital.Blazor.Components.CookieConsent.AspNetCore/BytexDigital.Blazor.Components.CookieConsent.AspNetCore.csproj
+++ b/BytexDigital.Blazor.Components.CookieConsent.AspNetCore/BytexDigital.Blazor.Components.CookieConsent.AspNetCore.csproj
@@ -22,7 +22,7 @@
         <PackageReleaseNotes>See https://github.com/BytexDigital/BytexDigital.Blazor.Components.CookieConsent</PackageReleaseNotes>
     </PropertyGroup>
 	
-    <PropertyGroup>
+	<PropertyGroup>
 		<IsTrimmable>true</IsTrimmable>
 		<EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 	</PropertyGroup>

--- a/BytexDigital.Blazor.Components.CookieConsent/Broadcasting/CookieConsentEventHandler.cs
+++ b/BytexDigital.Blazor.Components.CookieConsent/Broadcasting/CookieConsentEventHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -29,6 +30,7 @@ namespace BytexDigital.Blazor.Components.CookieConsent.Broadcasting
         protected readonly IJSRuntime _jsRuntime;
         protected readonly CookieConsentRuntimeContext _runtimeContext;
 
+        [DynamicDependency(nameof(OnReceivedBroadcastAsync))]
         public CookieConsentEventHandler(CookieConsentRuntimeContext runtimeContext, IJSRuntime jsRuntime, ICookieConsentInterop cookieConsentInterop)
         {
             _jsRuntime = jsRuntime;

--- a/BytexDigital.Blazor.Components.CookieConsent/Broadcasting/CookieConsentEventHandler.cs
+++ b/BytexDigital.Blazor.Components.CookieConsent/Broadcasting/CookieConsentEventHandler.cs
@@ -10,9 +10,6 @@ namespace BytexDigital.Blazor.Components.CookieConsent.Broadcasting
 {
     public class CookieConsentEventHandler
     {
-        protected const string JsInteropRegisterReceiver = "CookieConsent.RegisterBroadcastReceiver";
-        protected const string JsInteropBroadcast = "CookieConsent.BroadcastEvent";
-
         protected const string JsBroadcastEventCookiePreferencesChanged =
             nameof(JsBroadcastEventCookiePreferencesChanged);
 
@@ -26,20 +23,13 @@ namespace BytexDigital.Blazor.Components.CookieConsent.Broadcasting
             nameof(JsBroadcastEventScriptLoaded);
 
         protected readonly ICookieConsentInterop _cookieConsentInterop;
-        protected readonly Lazy<Task<IJSObjectReference>> _importModule;
-        protected readonly IJSRuntime _jsRuntime;
         protected readonly CookieConsentRuntimeContext _runtimeContext;
 
         [DynamicDependency(nameof(OnReceivedBroadcastAsync))]
-        public CookieConsentEventHandler(CookieConsentRuntimeContext runtimeContext, IJSRuntime jsRuntime, ICookieConsentInterop cookieConsentInterop)
+        public CookieConsentEventHandler(CookieConsentRuntimeContext runtimeContext, ICookieConsentInterop cookieConsentInterop)
         {
-            _jsRuntime = jsRuntime;
             _runtimeContext = runtimeContext;
             _cookieConsentInterop = cookieConsentInterop;
-            _importModule = new Lazy<Task<IJSObjectReference>>(() => _jsRuntime.InvokeAsync<IJSObjectReference>(
-                    "import",
-                    new object[] { "./_content/BytexDigital.Blazor.Components.CookieConsent/cookieconsent.js" })
-                .AsTask());
         }
 
         public event EventHandler<CookiePreferences> CookiePreferencesChanged;

--- a/BytexDigital.Blazor.Components.CookieConsent/BytexDigital.Blazor.Components.CookieConsent.csproj
+++ b/BytexDigital.Blazor.Components.CookieConsent/BytexDigital.Blazor.Components.CookieConsent.csproj
@@ -20,6 +20,11 @@
 		<PackageReleaseNotes>See https://github.com/BytexDigital/BytexDigital.Blazor.Components.CookieConsent</PackageReleaseNotes>
 		<LangVersion>10</LangVersion>
 	</PropertyGroup>
+	
+	<PropertyGroup>
+		<IsTrimmable>true</IsTrimmable>
+		<EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+	</PropertyGroup>
 
 	<ItemGroup>
 		<None Include="..\LICENSE.md">

--- a/BytexDigital.Blazor.Components.CookieConsent/CookieConsentExtensions.cs
+++ b/BytexDigital.Blazor.Components.CookieConsent/CookieConsentExtensions.cs
@@ -4,6 +4,7 @@ using BytexDigital.Blazor.Components.CookieConsent.Broadcasting;
 using System;
 using BytexDigital.Blazor.Components.CookieConsent.Dialogs.Prompt.Default;
 using BytexDigital.Blazor.Components.CookieConsent.Dialogs.Settings.Default;
+using BytexDigital.Blazor.Components.CookieConsent.Interop;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -29,6 +30,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 services.AddScoped<CookieConsentService, CookieConsentServiceProxy>();
             }
 
+            services.AddScoped<ICookieConsentInterop, CookieConsentInterop>();
             services.AddScoped<CookieConsentEventHandler>();
             services.AddScoped<CookieConsentLocalizer>();
 

--- a/BytexDigital.Blazor.Components.CookieConsent/CookieConsentOptions.cs
+++ b/BytexDigital.Blazor.Components.CookieConsent/CookieConsentOptions.cs
@@ -8,6 +8,15 @@ namespace BytexDigital.Blazor.Components.CookieConsent
     public class CookieConsentOptions
     {
         /// <summary>
+        ///     Specifies whether to import the JavaScript <c>'_content/BytexDigital.Blazor.Components.CookieConsent/cookieconsent.js'</c> file automatically.
+        ///     <para>
+        ///         If you disable this option, you must manually import your own JavaScript via the <c>script</c> tag.
+        ///     </para>
+        ///     Default is <c>true</c>.
+        /// </summary>
+        public bool ImportJsAutomatically { get; set; } = true;
+
+        /// <summary>
         ///     Revision of the cookie policy the user agrees to. If the user's agreed to policy number is any different than the
         ///     currently configured, the prompt for consent will appear again.
         /// </summary>

--- a/BytexDigital.Blazor.Components.CookieConsent/CookieConsentPreferencesVariantBase.cs
+++ b/BytexDigital.Blazor.Components.CookieConsent/CookieConsentPreferencesVariantBase.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace BytexDigital.Blazor.Components.CookieConsent
 {
     public abstract class CookieConsentPreferencesVariantBase
     {
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
         public abstract Type ComponentType { get; set; }
     }
 }

--- a/BytexDigital.Blazor.Components.CookieConsent/CookieConsentPromptVariantBase.cs
+++ b/BytexDigital.Blazor.Components.CookieConsent/CookieConsentPromptVariantBase.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace BytexDigital.Blazor.Components.CookieConsent
 {
     public abstract class CookieConsentPromptVariantBase
     {
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
         public abstract Type ComponentType { get; set; }
     }
 }

--- a/BytexDigital.Blazor.Components.CookieConsent/CookieConsentService.cs
+++ b/BytexDigital.Blazor.Components.CookieConsent/CookieConsentService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
@@ -30,6 +31,7 @@ namespace BytexDigital.Blazor.Components.CookieConsent
                 new object[] { "./_content/BytexDigital.Blazor.Components.CookieConsent/cookieconsent.js" })
             .AsTask();
 
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields, typeof(CookiePreferences))]
         public CookieConsentService(
             IOptions<CookieConsentOptions> options,
             IJSRuntime jsRuntime,

--- a/BytexDigital.Blazor.Components.CookieConsent/CookieConsentService.cs
+++ b/BytexDigital.Blazor.Components.CookieConsent/CookieConsentService.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using BytexDigital.Blazor.Components.CookieConsent.Broadcasting;
+using BytexDigital.Blazor.Components.CookieConsent.Interop;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
@@ -14,6 +15,7 @@ namespace BytexDigital.Blazor.Components.CookieConsent
 {
     public abstract class CookieConsentService
     {
+        protected readonly ICookieConsentInterop _cookieConsentInterop;
         protected readonly CookieConsentEventHandler _eventHandler;
         protected readonly IJSRuntime _jsRuntime;
         protected readonly ILogger<CookieConsentService> _logger;
@@ -31,6 +33,7 @@ namespace BytexDigital.Blazor.Components.CookieConsent
         public CookieConsentService(
             IOptions<CookieConsentOptions> options,
             IJSRuntime jsRuntime,
+            ICookieConsentInterop cookieConsentInterop,
             CookieConsentEventHandler eventHandler,
             CookieConsentRuntimeContext runtimeContext,
             ILogger<CookieConsentService> logger)
@@ -40,6 +43,7 @@ namespace BytexDigital.Blazor.Components.CookieConsent
             _eventHandler = eventHandler;
             _runtimeContext = runtimeContext;
             _logger = logger;
+            _cookieConsentInterop = cookieConsentInterop;
 
             // Create a default cookie preferences object that is returned when Javascript turns out to be unavailable
             // and no call to SavePreferences has been made yet.
@@ -112,16 +116,9 @@ namespace BytexDigital.Blazor.Components.CookieConsent
             // Attempt to write the new settings object to our cookie if possible.
             try
             {
-                var module = await Module;
+                await _cookieConsentInterop.SetCookieAsync(CreateCookieString(JsonSerializer.Serialize(cookiePreferences)));
 
-                await module.InvokeVoidAsync(
-                    "CookieConsent.SetCookie",
-                    CreateCookieString(JsonSerializer.Serialize(cookiePreferences)));
-
-                await module.InvokeVoidAsync(
-                    "CookieConsent.ApplyPreferences",
-                    cookiePreferences.AllowedCategories,
-                    cookiePreferences.AllowedServices);
+                await _cookieConsentInterop.ApplyPreferencesAsync(cookiePreferences.AllowedCategories, cookiePreferences.AllowedServices);
             }
             catch (Exception ex)
             {
@@ -188,10 +185,7 @@ namespace BytexDigital.Blazor.Components.CookieConsent
         {
             try
             {
-                var module = await Module;
-                var cookieValue = await module.InvokeAsync<string>(
-                    "CookieConsent.ReadCookie",
-                    _options.Value.CookieOptions.CookieName);
+                var cookieValue = await _cookieConsentInterop.ReadCookiesAsync(_options.Value.CookieOptions.CookieName);
 
                 // If the cookie value is empty, no cookie is set yet. In this case
                 // return default data.
@@ -222,10 +216,7 @@ namespace BytexDigital.Blazor.Components.CookieConsent
         {
             try
             {
-                var module = await Module;
-                var activatedScriptsJson = await module.InvokeAsync<string>(
-                    "CookieConsent.ReadLoadedScripts",
-                    cancellationToken);
+                var activatedScriptsJson = await _cookieConsentInterop.ReadLoadedScriptsAsync(cancellationToken);
 
                 return JsonSerializer.Deserialize<List<CookieConsentLoadedScript>>(activatedScriptsJson);
             }
@@ -280,8 +271,9 @@ namespace BytexDigital.Blazor.Components.CookieConsent
             return (await GetPreferencesAsync()).AcceptedRevision == _options.Value.Revision;
         }
 
-        public virtual async Task NotifyApplicationLoadedAsync()
+        public virtual Task NotifyApplicationLoadedAsync()
         {
+            return Task.CompletedTask;
         }
 
         protected virtual string CreateCookieString(string value)

--- a/BytexDigital.Blazor.Components.CookieConsent/CookieConsentService.cs
+++ b/BytexDigital.Blazor.Components.CookieConsent/CookieConsentService.cs
@@ -187,7 +187,7 @@ namespace BytexDigital.Blazor.Components.CookieConsent
         {
             try
             {
-                var cookieValue = await _cookieConsentInterop.ReadCookiesAsync(_options.Value.CookieOptions.CookieName);
+                var cookieValue = await _cookieConsentInterop.ReadCookieAsync(_options.Value.CookieOptions.CookieName);
 
                 // If the cookie value is empty, no cookie is set yet. In this case
                 // return default data.

--- a/BytexDigital.Blazor.Components.CookieConsent/CookieConsentService.cs
+++ b/BytexDigital.Blazor.Components.CookieConsent/CookieConsentService.cs
@@ -18,30 +18,21 @@ namespace BytexDigital.Blazor.Components.CookieConsent
     {
         protected readonly ICookieConsentInterop _cookieConsentInterop;
         protected readonly CookieConsentEventHandler _eventHandler;
-        protected readonly IJSRuntime _jsRuntime;
         protected readonly ILogger<CookieConsentService> _logger;
         protected readonly IOptions<CookieConsentOptions> _options;
         private readonly CookieConsentRuntimeContext _runtimeContext;
         protected CookiePreferences _cookiePreferencesCached;
-        protected Task<IJSObjectReference> _module;
         protected CookiePreferences _previousCookiePreferences;
-
-        protected Task<IJSObjectReference> Module => _module ??= _jsRuntime.InvokeAsync<IJSObjectReference>(
-                "import",
-                new object[] { "./_content/BytexDigital.Blazor.Components.CookieConsent/cookieconsent.js" })
-            .AsTask();
 
         [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields, typeof(CookiePreferences))]
         public CookieConsentService(
             IOptions<CookieConsentOptions> options,
-            IJSRuntime jsRuntime,
             ICookieConsentInterop cookieConsentInterop,
             CookieConsentEventHandler eventHandler,
             CookieConsentRuntimeContext runtimeContext,
             ILogger<CookieConsentService> logger)
         {
             _options = options;
-            _jsRuntime = jsRuntime;
             _eventHandler = eventHandler;
             _runtimeContext = runtimeContext;
             _logger = logger;

--- a/BytexDigital.Blazor.Components.CookieConsent/CookieConsentServiceAuthority.cs
+++ b/BytexDigital.Blazor.Components.CookieConsent/CookieConsentServiceAuthority.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using BytexDigital.Blazor.Components.CookieConsent.Broadcasting;
+using BytexDigital.Blazor.Components.CookieConsent.Interop;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
@@ -12,9 +13,10 @@ namespace BytexDigital.Blazor.Components.CookieConsent
         public CookieConsentServiceAuthority(
             IOptions<CookieConsentOptions> options,
             IJSRuntime jsRuntime,
+            ICookieConsentInterop cookieConsentInterop,
             CookieConsentEventHandler eventHandler,
             CookieConsentRuntimeContext runtimeContext,
-            ILogger<CookieConsentService> logger) : base(options, jsRuntime, eventHandler, runtimeContext, logger)
+            ILogger<CookieConsentService> logger) : base(options, jsRuntime, cookieConsentInterop, eventHandler, runtimeContext, logger)
         {
         }
 
@@ -26,10 +28,7 @@ namespace BytexDigital.Blazor.Components.CookieConsent
             {
                 if (await IsCurrentRevisionAcceptedAsync())
                 {
-                    var module = await Module;
-
-                    await module.InvokeVoidAsync(
-                        "CookieConsent.ApplyPreferences",
+                    await _cookieConsentInterop.ApplyPreferencesAsync(
                         preferences.AllowedCategories,
                         preferences.AllowedServices);
                 }

--- a/BytexDigital.Blazor.Components.CookieConsent/CookieConsentServiceAuthority.cs
+++ b/BytexDigital.Blazor.Components.CookieConsent/CookieConsentServiceAuthority.cs
@@ -12,11 +12,10 @@ namespace BytexDigital.Blazor.Components.CookieConsent
     {
         public CookieConsentServiceAuthority(
             IOptions<CookieConsentOptions> options,
-            IJSRuntime jsRuntime,
             ICookieConsentInterop cookieConsentInterop,
             CookieConsentEventHandler eventHandler,
             CookieConsentRuntimeContext runtimeContext,
-            ILogger<CookieConsentService> logger) : base(options, jsRuntime, cookieConsentInterop, eventHandler, runtimeContext, logger)
+            ILogger<CookieConsentService> logger) : base(options, cookieConsentInterop, eventHandler, runtimeContext, logger)
         {
         }
 

--- a/BytexDigital.Blazor.Components.CookieConsent/CookieConsentServiceProxy.cs
+++ b/BytexDigital.Blazor.Components.CookieConsent/CookieConsentServiceProxy.cs
@@ -1,4 +1,5 @@
 ﻿using BytexDigital.Blazor.Components.CookieConsent.Broadcasting;
+using BytexDigital.Blazor.Components.CookieConsent.Interop;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
@@ -10,9 +11,10 @@ namespace BytexDigital.Blazor.Components.CookieConsent
         public CookieConsentServiceProxy(
             IOptions<CookieConsentOptions> options,
             IJSRuntime jsRuntime,
+            ICookieConsentInterop cookieConsentInterop,
             CookieConsentEventHandler eventHandler,
             CookieConsentRuntimeContext runtimeContext,
-            ILogger<CookieConsentService> logger) : base(options, jsRuntime, eventHandler, runtimeContext, logger)
+            ILogger<CookieConsentService> logger) : base(options, jsRuntime, cookieConsentInterop, eventHandler, runtimeContext, logger)
         {
         }
     }

--- a/BytexDigital.Blazor.Components.CookieConsent/CookieConsentServiceProxy.cs
+++ b/BytexDigital.Blazor.Components.CookieConsent/CookieConsentServiceProxy.cs
@@ -2,7 +2,6 @@
 using BytexDigital.Blazor.Components.CookieConsent.Interop;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.JSInterop;
 
 namespace BytexDigital.Blazor.Components.CookieConsent
 {
@@ -10,11 +9,10 @@ namespace BytexDigital.Blazor.Components.CookieConsent
     {
         public CookieConsentServiceProxy(
             IOptions<CookieConsentOptions> options,
-            IJSRuntime jsRuntime,
             ICookieConsentInterop cookieConsentInterop,
             CookieConsentEventHandler eventHandler,
             CookieConsentRuntimeContext runtimeContext,
-            ILogger<CookieConsentService> logger) : base(options, jsRuntime, cookieConsentInterop, eventHandler, runtimeContext, logger)
+            ILogger<CookieConsentService> logger) : base(options, cookieConsentInterop, eventHandler, runtimeContext, logger)
         {
         }
     }

--- a/BytexDigital.Blazor.Components.CookieConsent/Dialogs/Prompt/Default/CookieConsentDefaultPromptVariant.cs
+++ b/BytexDigital.Blazor.Components.CookieConsent/Dialogs/Prompt/Default/CookieConsentDefaultPromptVariant.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace BytexDigital.Blazor.Components.CookieConsent.Dialogs.Prompt.Default
 {
@@ -7,6 +8,7 @@ namespace BytexDigital.Blazor.Components.CookieConsent.Dialogs.Prompt.Default
         /// <summary>
         /// Specifies the component type to use. Do not change unless you know what you are doing.
         /// </summary>
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
         public override Type ComponentType { get; set; } = typeof(CookieConsentDefaultPrompt);
 
         /// <summary>

--- a/BytexDigital.Blazor.Components.CookieConsent/Dialogs/Settings/Default/CookieConsentDefaultSettingsModalVariant.cs
+++ b/BytexDigital.Blazor.Components.CookieConsent/Dialogs/Settings/Default/CookieConsentDefaultSettingsModalVariant.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace BytexDigital.Blazor.Components.CookieConsent.Dialogs.Settings.Default
 {
     public class CookieConsentDefaultSettingsModalVariant : CookieConsentPreferencesVariantBase
     {
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
         public override Type ComponentType { get; set; } = typeof(CookieConsentDefaultSettingsModal);
     }
 }

--- a/BytexDigital.Blazor.Components.CookieConsent/Interop/CookieConsentInterop.cs
+++ b/BytexDigital.Blazor.Components.CookieConsent/Interop/CookieConsentInterop.cs
@@ -7,6 +7,13 @@ namespace BytexDigital.Blazor.Components.CookieConsent.Interop
 {
     internal class CookieConsentInterop : ICookieConsentInterop
     {
+        protected const string JsInteropRegisterReceiver = "CookieConsent.RegisterBroadcastReceiver";
+        protected const string JsInteropBroadcast = "CookieConsent.BroadcastEvent";
+        protected const string JsInteropReadLoadedScripts = "CookieConsent.ReadLoadedScripts";
+        protected const string JsInteropReadCookie = "CookieConsent.ReadCookie";
+        protected const string JsInteropSetCookie = "CookieConsent.SetCookie";
+        protected const string JsInteropApplyPreferences = "CookieConsent.ApplyPreferences";
+
         private readonly IJSRuntime _jsRuntime;
         private Task<IJSObjectReference> _module;
         private readonly IOptions<CookieConsentOptions> _options;
@@ -24,6 +31,45 @@ namespace BytexDigital.Blazor.Components.CookieConsent.Interop
             _jsRuntime = jsRuntime;
         }
 
+        public async Task RegisterBroadcastReceiverAsync<T>(DotNetObjectReference<T> dotNetObjectReference, bool isOsPlatform) where T : class
+        {
+            if (_options.Value.ImportJsAutomatically)
+            {
+                var module = await Module;
+
+                await module.InvokeVoidAsync(JsInteropRegisterReceiver,
+                    dotNetObjectReference,
+                    isOsPlatform);
+            }
+            else
+            {
+
+                await _jsRuntime.InvokeVoidAsync(JsInteropRegisterReceiver,
+                    dotNetObjectReference,
+                    isOsPlatform);
+            }
+        }
+
+        public async Task BroadcastEventAsync(bool isOsPlatform, string name, string data)
+        {
+            if (_options.Value.ImportJsAutomatically)
+            {
+                var module = await Module;
+
+                await module.InvokeVoidAsync(JsInteropBroadcast,
+                    !isOsPlatform, // Directed towards WASM?
+                    name, // Event name
+                    data); // Event data
+            }
+            else
+            {
+                await _jsRuntime.InvokeVoidAsync(JsInteropBroadcast,
+                    !isOsPlatform, // Directed towards WASM?
+                    name, // Event name
+                    data); // Event data
+            }
+        }
+
         public async Task<string> ReadLoadedScriptsAsync(CancellationToken cancellationToken)
         {
             if (_options.Value.ImportJsAutomatically)
@@ -31,7 +77,7 @@ namespace BytexDigital.Blazor.Components.CookieConsent.Interop
                 var module = await Module;
 
                 var activatedScriptsJson = await module.InvokeAsync<string>(
-                    "CookieConsent.ReadLoadedScripts",
+                    JsInteropReadLoadedScripts,
                     cancellationToken);
 
                 return activatedScriptsJson;
@@ -39,7 +85,7 @@ namespace BytexDigital.Blazor.Components.CookieConsent.Interop
             else
             {
                 var activatedScriptsJson = await _jsRuntime.InvokeAsync<string>(
-                    "CookieConsent.ReadLoadedScripts",
+                    JsInteropReadLoadedScripts,
                     cancellationToken);
 
                 return activatedScriptsJson;
@@ -52,16 +98,16 @@ namespace BytexDigital.Blazor.Components.CookieConsent.Interop
                 var module = await Module;
 
                 var cookieValue = await module.InvokeAsync<string>(
-                    "CookieConsent.ReadCookie", cookieName);
+                    JsInteropReadCookie, cookieName);
 
                 return cookieValue;
             }
             else
             {
                 var cookieValue = await _jsRuntime.InvokeAsync<string>(
-                    "CookieConsent.ReadCookie", cookieName);
+                    JsInteropReadCookie, cookieName);
 
-                return cookieValue; ;
+                return cookieValue;
             }
         }
 
@@ -72,12 +118,12 @@ namespace BytexDigital.Blazor.Components.CookieConsent.Interop
                 var module = await Module;
 
                 await module.InvokeVoidAsync(
-                    "CookieConsent.SetCookie", cookieString);
+                    JsInteropSetCookie, cookieString);
             }
             else
             {
                 await _jsRuntime.InvokeVoidAsync(
-                    "CookieConsent.SetCookie", cookieString);
+                    JsInteropSetCookie, cookieString);
             }
         }
 
@@ -88,14 +134,14 @@ namespace BytexDigital.Blazor.Components.CookieConsent.Interop
                 var module = await Module;
 
                 await module.InvokeVoidAsync(
-                    "CookieConsent.ApplyPreferences",
+                    JsInteropApplyPreferences,
                     allowedCategories,
                     allowedServices);
             }
             else
             {
                 await _jsRuntime.InvokeVoidAsync(
-                    "CookieConsent.ApplyPreferences",
+                    JsInteropApplyPreferences,
                     allowedCategories,
                     allowedServices);
             }

--- a/BytexDigital.Blazor.Components.CookieConsent/Interop/CookieConsentInterop.cs
+++ b/BytexDigital.Blazor.Components.CookieConsent/Interop/CookieConsentInterop.cs
@@ -31,7 +31,7 @@ namespace BytexDigital.Blazor.Components.CookieConsent.Interop
             _jsRuntime = jsRuntime;
         }
 
-        public async Task RegisterBroadcastReceiverAsync<T>(DotNetObjectReference<T> dotNetObjectReference, bool isOsPlatform) where T : class
+        public async Task RegisterBroadcastReceiverAsync<T>(DotNetObjectReference<T> dotNetObjectReference, bool isCallerWasm) where T : class
         {
             if (_options.Value.ImportJsAutomatically)
             {
@@ -39,32 +39,32 @@ namespace BytexDigital.Blazor.Components.CookieConsent.Interop
 
                 await module.InvokeVoidAsync(JsInteropRegisterReceiver,
                     dotNetObjectReference,
-                    isOsPlatform);
+                    isCallerWasm);
             }
             else
             {
 
                 await _jsRuntime.InvokeVoidAsync(JsInteropRegisterReceiver,
                     dotNetObjectReference,
-                    isOsPlatform);
+                    isCallerWasm);
             }
         }
 
-        public async Task BroadcastEventAsync(bool isOsPlatform, string name, string data)
+        public async Task BroadcastEventAsync(bool isDirectedTowardsWasm, string name, string data)
         {
             if (_options.Value.ImportJsAutomatically)
             {
                 var module = await Module;
 
                 await module.InvokeVoidAsync(JsInteropBroadcast,
-                    !isOsPlatform, // Directed towards WASM?
+                    !isDirectedTowardsWasm, // Directed towards WASM?
                     name, // Event name
                     data); // Event data
             }
             else
             {
                 await _jsRuntime.InvokeVoidAsync(JsInteropBroadcast,
-                    !isOsPlatform, // Directed towards WASM?
+                    !isDirectedTowardsWasm, // Directed towards WASM?
                     name, // Event name
                     data); // Event data
             }
@@ -91,7 +91,7 @@ namespace BytexDigital.Blazor.Components.CookieConsent.Interop
                 return activatedScriptsJson;
             }
         }
-        public async Task<string> ReadCookiesAsync(string cookieName)
+        public async Task<string> ReadCookieAsync(string cookieName)
         {
             if (_options.Value.ImportJsAutomatically)
             {

--- a/BytexDigital.Blazor.Components.CookieConsent/Interop/CookieConsentInterop.cs
+++ b/BytexDigital.Blazor.Components.CookieConsent/Interop/CookieConsentInterop.cs
@@ -1,0 +1,104 @@
+﻿using System.Threading;
+using Microsoft.Extensions.Options;
+using Microsoft.JSInterop;
+using System.Threading.Tasks;
+
+namespace BytexDigital.Blazor.Components.CookieConsent.Interop
+{
+    internal class CookieConsentInterop : ICookieConsentInterop
+    {
+        private readonly IJSRuntime _jsRuntime;
+        private Task<IJSObjectReference> _module;
+        private readonly IOptions<CookieConsentOptions> _options;
+
+        private Task<IJSObjectReference> Module => _module ??= _jsRuntime.InvokeAsync<IJSObjectReference>(
+                "import",
+                new object[] { "./_content/BytexDigital.Blazor.Components.CookieConsent/cookieconsent.js" })
+            .AsTask();
+
+        public CookieConsentInterop(
+            IOptions<CookieConsentOptions> options,
+            IJSRuntime jsRuntime)
+        {
+            _options = options;
+            _jsRuntime = jsRuntime;
+        }
+
+        public async Task<string> ReadLoadedScriptsAsync(CancellationToken cancellationToken)
+        {
+            if (_options.Value.ImportJsAutomatically)
+            {
+                var module = await Module;
+
+                var activatedScriptsJson = await module.InvokeAsync<string>(
+                    "CookieConsent.ReadLoadedScripts",
+                    cancellationToken);
+
+                return activatedScriptsJson;
+            }
+            else
+            {
+                var activatedScriptsJson = await _jsRuntime.InvokeAsync<string>(
+                    "CookieConsent.ReadLoadedScripts",
+                    cancellationToken);
+
+                return activatedScriptsJson;
+            }
+        }
+        public async Task<string> ReadCookiesAsync(string cookieName)
+        {
+            if (_options.Value.ImportJsAutomatically)
+            {
+                var module = await Module;
+
+                var cookieValue = await module.InvokeAsync<string>(
+                    "CookieConsent.ReadCookie", cookieName);
+
+                return cookieValue;
+            }
+            else
+            {
+                var cookieValue = await _jsRuntime.InvokeAsync<string>(
+                    "CookieConsent.ReadCookie", cookieName);
+
+                return cookieValue; ;
+            }
+        }
+
+        public async Task SetCookieAsync(string cookieString)
+        {
+            if (_options.Value.ImportJsAutomatically)
+            {
+                var module = await Module;
+
+                await module.InvokeVoidAsync(
+                    "CookieConsent.SetCookie", cookieString);
+            }
+            else
+            {
+                await _jsRuntime.InvokeVoidAsync(
+                    "CookieConsent.SetCookie", cookieString);
+            }
+        }
+
+        public async Task ApplyPreferencesAsync(string[] allowedCategories, string[] allowedServices)
+        {
+            if (_options.Value.ImportJsAutomatically)
+            {
+                var module = await Module;
+
+                await module.InvokeVoidAsync(
+                    "CookieConsent.ApplyPreferences",
+                    allowedCategories,
+                    allowedServices);
+            }
+            else
+            {
+                await _jsRuntime.InvokeVoidAsync(
+                    "CookieConsent.ApplyPreferences",
+                    allowedCategories,
+                    allowedServices);
+            }
+        }
+    }
+}

--- a/BytexDigital.Blazor.Components.CookieConsent/Interop/ICookieConsentInterop.cs
+++ b/BytexDigital.Blazor.Components.CookieConsent/Interop/ICookieConsentInterop.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace BytexDigital.Blazor.Components.CookieConsent.Interop
+{
+    public interface ICookieConsentInterop
+    {
+        Task<string> ReadLoadedScriptsAsync(CancellationToken cancellationToken = default);
+
+        Task<string> ReadCookiesAsync(string cookieName);
+
+        Task SetCookieAsync(string cookieString);
+
+        Task ApplyPreferencesAsync(string[] allowedCategories, string[] allowedServices);
+    }
+}

--- a/BytexDigital.Blazor.Components.CookieConsent/Interop/ICookieConsentInterop.cs
+++ b/BytexDigital.Blazor.Components.CookieConsent/Interop/ICookieConsentInterop.cs
@@ -1,10 +1,15 @@
-﻿using System.Threading;
+﻿using Microsoft.JSInterop;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace BytexDigital.Blazor.Components.CookieConsent.Interop
 {
     public interface ICookieConsentInterop
     {
+        Task RegisterBroadcastReceiverAsync<T>(DotNetObjectReference<T> dotNetObjectReference, bool isOsPlatform) where T : class;
+
+        Task BroadcastEventAsync(bool isOsPlatform, string name, string data);
+
         Task<string> ReadLoadedScriptsAsync(CancellationToken cancellationToken = default);
 
         Task<string> ReadCookiesAsync(string cookieName);

--- a/BytexDigital.Blazor.Components.CookieConsent/Interop/ICookieConsentInterop.cs
+++ b/BytexDigital.Blazor.Components.CookieConsent/Interop/ICookieConsentInterop.cs
@@ -6,13 +6,13 @@ namespace BytexDigital.Blazor.Components.CookieConsent.Interop
 {
     public interface ICookieConsentInterop
     {
-        Task RegisterBroadcastReceiverAsync<T>(DotNetObjectReference<T> dotNetObjectReference, bool isOsPlatform) where T : class;
+        Task RegisterBroadcastReceiverAsync<T>(DotNetObjectReference<T> dotNetObjectReference, bool isCallerWasm) where T : class;
 
-        Task BroadcastEventAsync(bool isOsPlatform, string name, string data);
+        Task BroadcastEventAsync(bool isDirectedTowardsWasm, string name, string data);
 
         Task<string> ReadLoadedScriptsAsync(CancellationToken cancellationToken = default);
 
-        Task<string> ReadCookiesAsync(string cookieName);
+        Task<string> ReadCookieAsync(string cookieName);
 
         Task SetCookieAsync(string cookieString);
 


### PR DESCRIPTION
Hi,

We are using this library for cookie consent, specifically on the MudBlazor website. 

We would like to be able to import our own version of cookieconsent.js, a minified version, and possibly change the JS script name. The reason for this is that the script is frequently blocked by adblockers:
<details>
  <summary>Exception</summary>

  ```javascript
blazor.webassembly.js:1 
 
 GET https://mudblazor.com/_content/BytexDigital.Blazor.Components.CookieConsent/cookieconsent.js net::ERR_BLOCKED_BY_CLIENT
dotnet.runtime.8.0.6.scyrrn9hx4.js:3 
 fail: BytexDigital.Blazor.Components.CookieConsent.CookieConsentService[0]
      Exception raised trying to run CookiePreferencesChanged event handler
Microsoft.JSInterop.JSException: Failed to fetch dynamically imported module: https://mudblazor.com/_content/BytexDigital.Blazor.Components.CookieConsent/cookieconsent.js
TypeError: Failed to fetch dynamically imported module: https://mudblazor.com/_content/BytexDigital.Blazor.Components.CookieConsent/cookieconsent.js
   at Microsoft.JSInterop.JSRuntime.<InvokeAsync>d__16`1[[Microsoft.JSInterop.IJSObjectReference, Microsoft.JSInterop, Version=8.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60]].MoveNext()
   at BytexDigital.Blazor.Components.CookieConsent.Broadcasting.CookieConsentEventHandler.PublishToJsAsync(String name, String data)
   at BytexDigital.Blazor.Components.CookieConsent.Broadcasting.CookieConsentEventHandler.BroadcastCookiePreferencesChangedAsync(CookiePreferences cookiePreferences)
   at BytexDigital.Blazor.Components.CookieConsent.CookieConsentService.PublishCookiePreferencesChanged(CookiePreferences preferences)
   at BytexDigital.Blazor.Components.CookieConsent.CookieConsentServiceAuthority.NotifyApplicationLoadedAsync()
  ```
  
</details>

With `ImportJsAutomatically`, you can disable the automatic import of the JS module, allowing users to add their own script via:
```html
<script src="_content/XYZProject/cookieconsent.min.js"></script>
```
I have also added an `ICookieConsentInterop` interface that can be replaced with your own implementation via dependency injection. This could be useful if you want to change the JS method names or add additional logic, such as custom error handling. Just in case someone wants to have more control. I hope this makes sense.