### PR TITLE
Fixed CookiePreferences equality check

### DIFF
--- a/BytexDigital.Blazor.Components.CookieConsent/CookiePreferences.cs
+++ b/BytexDigital.Blazor.Components.CookieConsent/CookiePreferences.cs
@@ -21,7 +21,7 @@ namespace BytexDigital.Blazor.Components.CookieConsent
                 return false;
             }
 
-            if (AllowedServices.Intersect(other.AllowedServices).Count() != AllowedCategories.Length)
+            if (AllowedServices.Intersect(other.AllowedServices).Count() != AllowedServices.Length)
             {
                 return false;
             }


### PR DESCRIPTION
The number of services was compared with the number of categories.
The event CookieConsentService.CookiePreferencesChanged keeps firing, even when the preferences have not changed.

It doesn't seem right.